### PR TITLE
Fix cv.R train-test split

### DIFF
--- a/flowmix/R/cv.R
+++ b/flowmix/R/cv.R
@@ -142,17 +142,39 @@ one_job <- function(ialpha, ibeta, ifold, irep, folds, destin,
   # train.count = countslist[-test.inds]
   # train.X = X[-test.inds,, drop=FALSE]
 
-  # These lines assume rownames(X) == 1:nrow(X) or is null,
-  # names(ylist) == 1:length(ylist) or is null, and  
-  # names(countslist) == 1:length(countslist) or is null.
-  # This preserves original indices if cross-validation is performed on 
-  # a subset of the data.
-  test.dat = ylist[as.character(test.inds)]
-  test.count = countslist[as.character(test.inds)]
-  test.X = X[as.character(test.inds), , drop = FALSE]
-  train.dat = ylist[setdiff(names(ylist), test.inds)]
-  train.count = countslist[setdiff(names(countslist), test.inds)]
-  train.X = X[setdiff(rownames(X), test.inds), , drop = FALSE]
+  # Three cases: 
+  # 1. names(ylist) & others are arbitrary but equal
+  # 2. names(ylist) & others are equal to as.character(1:length(ylist)) (this is to 
+  #   allow cross-validation using a subset of the original data)
+  # 3. at least one of the names() or rownames() is NULL
+
+  # In the first and third case, we use test.inds directly to subset the data
+  # In the second case, we assume that ylist, countslist, and X are subsets of the 
+  #   original data but `test.inds` refers to indices from the original (entire) 
+  #   dataset. names(ylist) and the like store 1:length(orig_ylist)
+  #   so that subsetting does not change the indices of the data points.
+
+  # Rough solution for now
+  if(identical(names(ylist), 1:length(ylist)) & 
+     identical(names(countslist), 1:length(countslist)) & 
+     identical(rownames(X), 1:nrow(X))) # case 2
+  {
+    test.inds <- as.character(test.inds)
+    train.inds <- setdiff(names(ylist), test.inds) 
+
+    train.dat = ylist[train.inds]
+    train.count = countslist[train.inds]
+    train.X = X[train.inds, , drop = FALSE]
+  } else { # cases 1 & 3
+    train.dat = ylist[-test.inds]
+    train.count = countslist[-test.inds]
+    train.X = X[-test.inds,, drop=FALSE]
+  }
+  
+  # cases 1, 2, and 3
+  test.dat = ylist[test.inds]
+  test.count = countslist[test.inds]
+  test.X = X[test.inds,,drop=FALSE]
 
   ## Check whether this job has been done already.
   filename = make_cvscore_filename(ialpha, ibeta, ifold, irep, sim, isim)

--- a/flowmix/R/cv.R
+++ b/flowmix/R/cv.R
@@ -143,7 +143,7 @@ one_job <- function(ialpha, ibeta, ifold, irep, folds, destin,
   # train.X = X[-test.inds,, drop=FALSE]
 
   # Three cases: 
-  # 1. names(ylist) & others are arbitrary but equal
+  # 1. names(ylist) & others are arbitrary
   # 2. names(ylist) & others are equal to as.character(1:length(ylist)) (this is to 
   #   allow cross-validation using a subset of the original data)
   # 3. at least one of the names() or rownames() is NULL


### PR DESCRIPTION
Please see the comment starting with "three cases" in cv.R for an explanation. This should fix the case in issue  #12  when the names() or rownames() are NULL.